### PR TITLE
Demo for the `@scikit-learn-bot update lock-files` command (legacy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 This repository is for testing some GitHub workflows.
+

--- a/files/update-lock-files.txt
+++ b/files/update-lock-files.txt
@@ -1,3 +1,4 @@
 select_build='', skip_build=None, select_tag=None
 select_build='doc', skip_build='doc_min_dependencies', select_tag=None
 select_build='', skip_build='doc', select_tag='main-ci'
+select_build='', skip_build=None, select_tag=None

--- a/files/update-lock-files.txt
+++ b/files/update-lock-files.txt
@@ -2,3 +2,4 @@ select_build='', skip_build=None, select_tag=None
 select_build='doc', skip_build='doc_min_dependencies', select_tag=None
 select_build='', skip_build='doc', select_tag='main-ci'
 select_build='', skip_build=None, select_tag=None
+select_build='', skip_build=None, select_tag=None

--- a/files/update-lock-files.txt
+++ b/files/update-lock-files.txt
@@ -1,2 +1,3 @@
 select_build='', skip_build=None, select_tag=None
 select_build='doc', skip_build='doc_min_dependencies', select_tag=None
+select_build='', skip_build='doc', select_tag='main-ci'

--- a/files/update-lock-files.txt
+++ b/files/update-lock-files.txt
@@ -1,1 +1,2 @@
 select_build='', skip_build=None, select_tag=None
+select_build='doc', skip_build='doc_min_dependencies', select_tag=None

--- a/files/update-lock-files.txt
+++ b/files/update-lock-files.txt
@@ -1,0 +1,1 @@
+select_build='', skip_build=None, select_tag=None


### PR DESCRIPTION
Check the workflow file [here](https://github.com/Charlie-XIAO/github-actions-test/blob/main/.github/workflows/pr-update-lock-files-command.yaml).

- Leave a comment, starting with `@scikit-learn-bot update lock-files`
- Check the commit message if a marker is expected
- Check the commit contents: there should be a new line containing the values of `select_tag`, `select_build`, and `skip_build`

On top of #8 this version has the following major changes:

- I've changed the default permissions of this repo from "Read and write permissions" to "Read repository contents and package permissions". This would require the additional `content: write` permission in the workflow file. (If we want to comment in the PR I believe `pull-request: write` is needed as well.) [scikit-learn/scikit-learn#29505 (comment)](https://github.com/scikit-learn/scikit-learn/pull/29505#issuecomment-2248245812)
- I've used a Python script to implement the parsing logic. [build_tools/pr_update_lock_files.py](https://github.com/Charlie-XIAO/github-actions-test/blob/main/build_tools/pr_update_lock_files.py) is called in the workflow file, which reads the comment from the environment variable. It performs the parsing logic and executes [build_tools/pr_update_lock_files_helper.py](https://github.com/Charlie-XIAO/github-actions-test/blob/main/build_tools/pr_update_lock_files_helper.py) which has the same CLI as `build_tools/update_environments_and_lock_files` of scikit-learn but only appends a line to the `files/update-lock-files.txt` file instead of actually doing the update. It then does the git commit and push as well. [scikit-learn/scikit-learn#29505 (comment)](https://github.com/scikit-learn/scikit-learn/pull/29505#issuecomment-2248245812)
- Changed the email to noreply@github.com; now it looks like a commit from `web-flow` (as expected). [scikit-learn/scikit-learn#29505 (comment)](https://github.com/scikit-learn/scikit-learn/pull/29505#discussion_r1692598735)